### PR TITLE
Fix fail on asset compilation

### DIFF
--- a/lib/execjs/encoding.rb
+++ b/lib/execjs/encoding.rb
@@ -1,26 +1,18 @@
 module ExecJS
   # Encodes strings as UTF-8
   module Encoding
-    if RUBY_ENGINE == 'jruby' || RUBY_ENGINE == 'rbx'
-      # workaround for jruby bug http://jira.codehaus.org/browse/JRUBY-6588
-      # workaround for rbx bug https://github.com/rubinius/rubinius/issues/1729
-      def encode(string)
-        if string.encoding.name == 'ASCII-8BIT'
-          data = string.dup
-          data.force_encoding('UTF-8')
+    def encode(string)
+      if string.encoding.name == 'ASCII-8BIT'
+        data = string.dup
+        data.force_encoding('UTF-8')
 
-          unless data.valid_encoding?
-            raise ::Encoding::UndefinedConversionError, "Could not encode ASCII-8BIT data #{string.dump} as UTF-8"
-          end
-        else
-          data = string.encode('UTF-8')
+        unless data.valid_encoding?
+          raise ::Encoding::UndefinedConversionError, "Could not encode ASCII-8BIT data #{string.dump} as UTF-8"
         end
-        data
+      else
+        data = string.encode('UTF-8')
       end
-    else
-      def encode(string)
-        string.encode('UTF-8')
-      end
+      data
     end
   end
 end


### PR DESCRIPTION
It fix `Encoding::UndefinedConversionError: "\xE6" from ASCII-8BIT to UTF-8` bug on ruby-2.2.2, rails-4.2.4
